### PR TITLE
[SECURITY] Fix Cross-Site Scripting

### DIFF
--- a/admin/new_user.php
+++ b/admin/new_user.php
@@ -35,10 +35,10 @@ function list_groups()
                 NoCSRF::check('csrf_token', $_POST, true, 60*10, true);
                 
 
-                $username = $_POST['username'];
-                $email = $_POST['email'];
+                $username = clean($_POST['username']);
+                $email = clean($_POST['email']);
                 $password = $_POST['password'];
-                $usergroup = $_POST['usergroup'];
+                $usergroup = clean($_POST['usergroup']);
                 $time = time();
 
                 if (!$username) {


### PR DESCRIPTION
CVE assigned is: CVE-2019-8348.

This prevents another authenticated users with administrator privileges to insert a new user with specially-crafted HTML and Javascript payload in username field (and others).